### PR TITLE
Tox setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src.egg-info/
 src.egg-info/PKG-INFO
 src.egg-info/SOURCES.txt
 .tox/
+42.0

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ TACOCAT.csv
 *_Axial_Temperatures.svg
 *_table.csv
 *_table.xlsx
+.coverage
+src.egg-info/
+src.egg-info/PKG-INFO
+src.egg-info/SOURCES.txt
+.tox/

--- a/LoadedTACO/src/Flux_Profiles.py
+++ b/LoadedTACO/src/Flux_Profiles.py
@@ -1,7 +1,4 @@
 import numpy as np
-import matplotlib.pyplot as plt 
-import pandas as pd
-import math
 import os
 import sys
 import LoadedTACO.src.Geometry_Value as geometry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
 [build-system]
 requires = ["setuptools>=42.0","wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "--cov=src"
+testpaths = [
+	"tests",
+]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 request==2.26.0
+pytest==7.1.3
+pytest-cov==3.0.0
+tox==3.24.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-requests==2.28.0
-pytest==7.1.3
-pytest-cov==3.0.0
-tox==3.24.3
+requests==2.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-request==2.26.0
+requests==2.28.0
 pytest==7.1.3
 pytest-cov==3.0.0
 tox==3.24.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,5 @@
+pytest==7.0.0
+pytest-cov==3.0.0
+tox==3.27.0
+numpy==1.19.5
+matplotlib==3.3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,5 +26,5 @@ testing =
 	tox>=3.24
 
 [options.package_data]
-slapping = py.typed
+src = py.typed
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,13 @@ python_requires = >=3.6
 package_dir =
 	=LoadedTACO
 zip_safe = no
+
+[options.testing_require]
+testing =
+	pytest>=6.0
+	pytest-cov>=2.0
+	tox>=3.24
+
+[options.package_data]
+slapping = py.typed
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,8 +6,12 @@ license = MIT
 license_file = LICENSE
 platforms = windows, unix, osx
 classifiers =
-	Programming Language :: Python :: 2
 	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3 :: Only
+	Programming Language :: Python :: 3.6
+	Programming Language :: Python :: 3.7
+	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: 3.9
 
 [Options]
 packages =
@@ -19,7 +23,7 @@ package_dir =
 	=LoadedTACO
 zip_safe = no
 
-[options.testing_require]
+[options.extras_require]
 testing =
 	pytest>=6.0
 	pytest-cov>=2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+minversion = 3.8.0
+envlist = py36, py37, py38, py39
+isolated_build = true
+
+[testenv]
+setenv = 
+	PYTHONPATH = {toxinidir}
+deps =
+	-r{toxinidir}/requirements_dev.txt
+commands =
+	pytest --basetemp={envtmpdir}


### PR DESCRIPTION
This pull request uses tox to set up multiple testing environments and runs pytest for py36, py37, py38, py39

tox generally won't be used for someone using TACOCAT or a developer working on TACOCAT but tox will be used by github actions to automatically run test with every push and pull request

to run tox you use `tox -r` in the TACOCAT directory

A successful test run looks like
<img width="665" alt="tox successful run" src="https://user-images.githubusercontent.com/106993557/201194405-cd6e7011-d2ed-46f7-a3d1-1bfb23065f7d.png">
